### PR TITLE
Mimic UITextField Behavior + Rotation Bug Fix

### DIFF
--- a/Classes/KTTextView.m
+++ b/Classes/KTTextView.m
@@ -59,6 +59,8 @@
    [self addSubview:_placeholder];
    [_placeholder sizeToFit];
    [self sendSubviewToBack:_placeholder];
+    
+   [_placeholder setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
    
    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textChanged:) name:UITextViewTextDidChangeNotification object:nil];
    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(getFocus:) name:UITextViewTextDidBeginEditingNotification object:nil];


### PR DESCRIPTION
- Register for UITextViewTextDidBeginEditingNotification & UITextViewTextDidEndEditingNotification and mimic UITextField placeholder behavior.
- setAutoresizingMask to fix bug when user rotate the device. The placeholder was displayed on multiple lines.
